### PR TITLE
Fix collapsible for long content

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -452,16 +452,11 @@ legend {
 .collapse {
     margin-top: 1rem;
     margin-bottom: 2rem;
-    display: block;
-    max-height: 0;
-    overflow: hidden;
-    transition: max-height .5s cubic-bezier(0, 1, 0, 1);
+    display: none;
 }
 
 .collapse.show {
-    max-height: 99em;
-    transition: max-height .5s ease-in-out;
-    overflow: visible;
+    display: block;
 }
 
 a.collapse-toggle {


### PR DESCRIPTION
Tento pull request řeší #127. Řešení však zároveň odebírá animaci rozbalování což mě osobně nevadí, ale nevím na kolik se k ní tíhne. 

Pokud bychom chtěli zachovat animaci, tak mě nenapadá jiné nenáročné řešení než zvýšit `max-height` na nějakou absurdně velkou hodnotu.